### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "react-dom": "^16.8.6",
     "topology-activity-diagram": "^0.0.4",
     "topology-class-diagram": "^0.0.1",
-    "topology-core": "^0.0.19",
+    "topology-core": "^0.2.17",
     "topology-flow-diagram": "^0.0.1",
     "topology-sequence-diagram": "^0.0.4",
     "umi-request": "^1.2.11"


### PR DESCRIPTION
1 .fix: 0.0.19 版本下无法正常显示部分绘图的作品。 
2.fix: 
在0.0.19版本中如果data下不存在nodes属性, 页面会进行报错崩溃。
 ``` tsx 
if (data && data.id ) {
      this.canvas.open(data.data)
    }
 ```
 在0.0.19下没有对data下的nodes做是否存在的校验, 在0.2.17版本中有此校验, 建议升级依赖。